### PR TITLE
Add a temporary NOPASSWD to sudoers.d to reduce friction of strap

### DIFF
--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -3,6 +3,8 @@
 #/ Install development dependencies on macOS.
 set -e
 
+caffeinate -di -w $$ &
+
 [ "$1" = "--debug" ] && STRAP_DEBUG="1"
 STRAP_SUCCESS=""
 

--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -372,5 +372,18 @@ if [ -n "$CUSTOM_BREW_COMMAND" ]; then
   logk
 fi
 
+# Run post-install dotfiles script
+if [ -d ~/.dotfiles ]; then
+  (
+    cd ~/.dotfiles
+    for i in script/postsetup; do
+      if [ -f "$i" ] && [ -x "$i" ]; then
+        log "Running dotfiles $i:"
+        "$i" 2>/dev/null
+      fi
+    done
+  )
+fi
+
 STRAP_SUCCESS="1"
 log "Your system is now Strap'd! You should restart NOW to complete disk encryption and patch updates!"

--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -8,10 +8,7 @@ STRAP_SUCCESS=""
 
 cleanup() {
   set +e
-  if [ -n "$STRAP_SUDO_WAIT_PID" ]; then
-    sudo kill "$STRAP_SUDO_WAIT_PID"
-  fi
-  sudo -k
+  remove_sudo_nopasswd
   rm -f "$CLT_PLACEHOLDER"
   if [ -z "$STRAP_SUCCESS" ]; then
     if [ -n "$STRAP_STEP" ]; then
@@ -48,30 +45,49 @@ STDIN_FILE_DESCRIPTOR="0"
 # CUSTOM_BREW_COMMAND=
 STRAP_ISSUES_URL='https://github.com/MikeMcQuaid/strap/issues/new'
 
-# We want to always prompt for sudo password at least once rather than doing
-# root stuff unexpectedly.
-sudo -k
-
-# Initialise (or reinitialise) sudo to save unhelpful prompts later.
-sudo_init() {
-  if ! sudo -vn &>/dev/null; then
-    if [ -n "$STRAP_SUDOED_ONCE" ]; then
-      echo "--> Re-enter your password (for sudo access; sudo has timed out):"
-    else
-      echo "--> Enter your password (for sudo access):"
-    fi
-    sudo /usr/bin/true
-    STRAP_SUDOED_ONCE="1"
-  fi
-}
-
 abort() { STRAP_STEP="";   echo "!!! $*" >&2; exit 1; }
-log()   { STRAP_STEP="$*"; sudo_init; echo "--> $*"; }
-logn()  { STRAP_STEP="$*"; sudo_init; printf -- "--> %s " "$*"; }
+log()   { STRAP_STEP="$*"; echo "--> $*"; }
+logn()  { STRAP_STEP="$*"; printf -- "--> %s " "$*"; }
 logk()  { STRAP_STEP="";   echo "OK"; }
 escape() {
   printf '%s' "${1//\'/\'}"
 }
+
+# We want to always prompt for sudo password at least once rather than doing
+# root stuff unexpectedly.
+sudo -k
+
+SUDOERS_FILE_NAME=/etc/sudoers.d/strap-nopasswd
+SUDOERS_INSTALLED="0"
+
+# Write out a temporary sudoers file that gives the current user a much longer timeout
+add_sudo_nopasswd() {
+  cat | sudo tee ${SUDOERS_FILE_NAME} << EOF
+${USER} ALL=(ALL) NOPASSWD:ALL
+EOF
+  SUDOERS_INSTALLED="1"
+}
+
+# Remove the sudoers file and reset permissions
+remove_sudo_nopasswd() {
+  if [ ${SUDOERS_INSTALLED} -ne "0" ]
+  then
+    logn "Removing NOPASSWD sudoers file: "
+    sudo rm -f ${SUDOERS_FILE_NAME}
+    logk
+  fi
+  sudo -K
+}
+
+# Initialise (or reinitialise) sudo to save unhelpful prompts later.
+sudo_init() {
+  if ! sudo -vn &>/dev/null; then
+    log "--> Enter your password (for sudo access):"
+    add_sudo_nopasswd
+  fi
+}
+
+sudo_init
 
 MACOS_VERSION="$(sw_vers -productVersion)"
 echo "$MACOS_VERSION" | grep $Q -E "^10.(9|10|11|12|13|14)" || {
@@ -357,4 +373,4 @@ if [ -n "$CUSTOM_BREW_COMMAND" ]; then
 fi
 
 STRAP_SUCCESS="1"
-log "Your system is now Strap'd!"
+log "Your system is now Strap'd! You should restart NOW to complete disk encryption and patch updates!"

--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -11,6 +11,8 @@ STRAP_SUCCESS=""
 cleanup() {
   set +e
   remove_sudo_nopasswd
+  unset AD_USERNAME
+  unset AD_PASSWORD
   rm -f "$CLT_PLACEHOLDER"
   if [ -z "$STRAP_SUCCESS" ]; then
     if [ -n "$STRAP_STEP" ]; then
@@ -98,6 +100,14 @@ echo "$MACOS_VERSION" | grep $Q -E "^10.(9|10|11|12|13|14)" || {
 
 [ "$USER" = "root" ] && abort "Run Strap as yourself, not root."
 groups | grep $Q admin || abort "Add $USER to the admin group."
+
+logn "Please enter your AD/Windows username (usually Firstname_Lastname): "
+read AD_USERNAME
+logn " and now your AD/Windows password: "
+read -s AD_PASSWORD
+echo
+export AD_USERNAME
+export AD_PASSWORD
 
 # Set some basic security settings.
 logn "Configuring security settings:"


### PR DESCRIPTION
I've been doing a bit more work trying to improve the experience of strap.

The main thing I've been trying to fix is avoiding multiple password prompts. This happens in two scenarios:
 - when the sudo validation times out
 - when a sub process uses sudo

The first of these is largely solved by using `sudo -v` either in the script or as a background process. 

In the second case the sudo session that is valid for the TTY running is _not_ valid when run by a subprocess (as this looks for a sudo session that is valid for a given parent PID instead of for the TTY). We hit this problem when installing certain casks such as java8.

Experiments have ruled a number of options and there are a couple of options remaining:
 - re-write the timestamp file and set the timestamp type to `TS_GLOBAL` (the sudo source code then doesn't check the TTY/PPID)
 - temporarily add a file to /etc/sudoers.d/xxx with ALL:NOPASSWD access for the current user (and remove this file during cleanup)

The first of these requires creating a tool that understands the binary timestamp format. The safest way of doing that is linking to the header file from sudo. This is not really ideal.

The second has been tested and works well but does allow all sudo from the user. If cleanup fails (probably in an extreme scenario, e.g. a power down) then this file could remain without the user realising it.